### PR TITLE
Add optional debug control

### DIFF
--- a/ConfigWebServer.cpp
+++ b/ConfigWebServer.cpp
@@ -1,6 +1,6 @@
 #include "ConfigWebServer.h"
 
-ConfigWebServer::ConfigWebServer() : server(80) {}
+ConfigWebServer::ConfigWebServer(bool debug_) : server(80), debug(debug_) {}
 
 void ConfigWebServer::begin(const String& title_) {
   title = title_;
@@ -95,27 +95,35 @@ void ConfigWebServer::saveToJSON() {
   if (f) {
     serializeJson(doc, f);
     f.close();
-    Serial.println("[SAVE] Config saved to /config.json");
+    if (debug) {
+      Serial.println("[SAVE] Config saved to /config.json");
 
-    // Print JSON to Serial for debugging
-    serializeJsonPretty(doc, Serial);
-    Serial.println();
+      // Print JSON to Serial for debugging
+      serializeJsonPretty(doc, Serial);
+      Serial.println();
+    }
 
   } else {
-    Serial.println("[ERROR] Failed to open /config.json for writing");
+    if (debug) {
+      Serial.println("[ERROR] Failed to open /config.json for writing");
+    }
   }
 }
 
 
 void ConfigWebServer::loadFromJSON() {
   if (!SPIFFS.exists("/config.json")) {
-    Serial.println("[LOAD] /config.json not found");
+    if (debug) {
+      Serial.println("[LOAD] /config.json not found");
+    }
     return;
   }
 
   File f = SPIFFS.open("/config.json", FILE_READ);
   if (!f) {
-    Serial.println("[ERROR] Failed to open /config.json for reading");
+    if (debug) {
+      Serial.println("[ERROR] Failed to open /config.json for reading");
+    }
     return;
   }
 
@@ -124,7 +132,9 @@ void ConfigWebServer::loadFromJSON() {
   f.close();
 
   if (err) {
-    Serial.println("[ERROR] JSON deserialization failed");
+    if (debug) {
+      Serial.println("[ERROR] JSON deserialization failed");
+    }
     return;
   }
 
@@ -140,5 +150,7 @@ void ConfigWebServer::loadFromJSON() {
     }
   }
 
-  Serial.println("[LOAD] Config loaded from /config.json");
+  if (debug) {
+    Serial.println("[LOAD] Config loaded from /config.json");
+  }
 }

--- a/ConfigWebServer.h
+++ b/ConfigWebServer.h
@@ -18,7 +18,7 @@ struct ConfigVar {
 
 class ConfigWebServer {
 public:
-  ConfigWebServer();
+  explicit ConfigWebServer(bool debug = false);
   void begin(const String& title = "ESP Config");
   void addVariable(const String& name, const String& label, int* ptr, int minVal, int maxVal);
   void addVariable(const String& name, const String& label, float* ptr, float minVal, float maxVal);
@@ -31,6 +31,7 @@ private:
   WebServer server;
   std::vector<ConfigVar> vars;
   String title;
+  bool debug;
   void handleRoot();
   void handleSave();
 };

--- a/examples/TestConfigWebServer.ino
+++ b/examples/TestConfigWebServer.ino
@@ -5,7 +5,7 @@ int brightness = 75;
 float threshold = 2.5;
 bool enabled = true;
 unsigned long lastVarShown;
-ConfigWebServer configServer;
+ConfigWebServer configServer(true);
 
 void setup() {
   Serial.begin(115200);


### PR DESCRIPTION
## Summary
- add a `debug` parameter to `ConfigWebServer` constructor
- gate Serial logging on the `debug` flag
- show enabling debug in the example sketch

## Testing
- `apt-get update` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_688cbb90025c832dbaaa442c9292e07e